### PR TITLE
fix: Deprecated `stylelint-scss` 2.0 rule `at-import-no-partial-extension`, use `at-import-partial-extension-blacklist` instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+* Deprecated: `at-import-no-partial-extension`. Use `at-import-partial-extension-blacklist` instead.
+
 # 0.1.0
 
 * Updated: Update to `stylelint` v7.x.

--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ module.exports = {
     "selector-no-vendor-prefix": true,
     "string-quotes": "double",
     "value-no-vendor-prefix": true,
-    "scss/at-import-no-partial-extension": true,
+    "scss/at-import-partial-extension-blacklist": ["scss"],
     "scss/at-import-no-partial-leading-underscore": true,
     "scss/selector-no-redundant-nesting-selector": true,
   },


### PR DESCRIPTION
Fixes #18
